### PR TITLE
Reassure compiler that parse_generic_args() always returns a value

### DIFF
--- a/dbus-proxy.c
+++ b/dbus-proxy.c
@@ -35,6 +35,7 @@ static const char *argv0;
 static GList *proxies;
 static int sync_fd = -1;
 
+static void usage (int ecode, FILE *out) G_GNUC_NORETURN;
 static void
 usage (int ecode, FILE *out)
 {


### PR DESCRIPTION
If it isn't told that usage() never returns, gcc 8 warns:

    dbus-proxy.c: In function ‘parse_generic_args’:
    dbus-proxy.c:215:1: warning: control reaches end of non-void function [-Wreturn-type]