### PR TITLE
Improve compatibility with older OSs

### DIFF
--- a/backport-autoptr.h
+++ b/backport-autoptr.h
@@ -183,8 +183,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantIter, g_variant_iter_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantDict, g_variant_dict_unref)
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GVariantDict, g_variant_dict_clear)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantType, g_variant_type_free)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocess, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocessLauncher, g_object_unref)
 
 /* Add GObject-based types as needed. */
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GAsyncResult, g_object_unref)

--- a/tests/test-proxy.c
+++ b/tests/test-proxy.c
@@ -68,7 +68,6 @@ setup (Fixture *f,
                                                 "--session",
                                                 "--print-address=1",
                                                 "--nofork",
-                                                "--nosyslog",
                                                 NULL);
   g_assert_no_error (error);
   g_assert_nonnull (f->dbus_daemon);

--- a/tests/test-proxy.c
+++ b/tests/test-proxy.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <string.h>
 
 #include <glib.h>
 #include <glib-unix.h>

--- a/tests/test-proxy.c
+++ b/tests/test-proxy.c
@@ -27,6 +27,8 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 
+#include "backport-autoptr.h"
+
 #define DBUS_SERVICE_DBUS "org.freedesktop.DBus"
 #define DBUS_PATH_DBUS "/org/freedesktop/DBus"
 #define DBUS_INTERFACE_DBUS "org.freedesktop.DBus"


### PR DESCRIPTION
Testing #5 on Travis-CI revealed some incompatibilities with older GLib and dbus versions:

* backport-autoptr.h declared autoptr cleanup for GSubprocess twice
* test-proxy.c didn't use backport-autoptr.h
* test-proxy.c gave dbus-daemon an option that was only introduced recently (and seems to be unnecessary here)

This pull request makes it work with GLib 2.40 on Ubuntu 14.04.

---

I'm happy to de-support older GLib releases as needed - Flatpak officially only supports GLib 2.44 and up, although I have patches that made Flatpak 1.0.x work on 2.42 and probably also 2.40.

We should probably test regularly on a distro that has the oldest GLib we support, for which see a subsequent pull request that adds Travis-CI integration.