### PR TITLE
Add Travis-CI integration, based on what I contributed to dbus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Copyright © 2015-2018 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+sudo: required
+dist: xenial
+language: c
+script:
+  - ./tests/ci-install.sh
+  - ci_parallel=2 ci_sudo=yes ./tests/ci-build.sh
+
+env:
+  # GLib 2.48
+  - ci_suite=xenial
+  # GLib 2.40. Not building the debug variant because the compiler is too
+  # old to support -fsanitize=address
+  - ci_docker=ubuntu:trusty ci_distro=ubuntu ci_suite=trusty ci_variant=production
+  # GLib 2.42
+  - ci_docker=debian:jessie-slim ci_distro=debian ci_suite=jessie
+  # GLib 2.58
+  - ci_docker=debian:buster-slim ci_distro=debian ci_suite=buster
+
+# vim:set sw=2 sts=2 et:

--- a/backport-autoptr.h
+++ b/backport-autoptr.h
@@ -183,8 +183,6 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantIter, g_variant_iter_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantDict, g_variant_dict_unref)
 G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(GVariantDict, g_variant_dict_clear)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GVariantType, g_variant_type_free)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocess, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(GSubprocessLauncher, g_object_unref)
 
 /* Add GObject-based types as needed. */
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GAsyncResult, g_object_unref)

--- a/tests/ci-Dockerfile.in
+++ b/tests/ci-Dockerfile.in
@@ -1,0 +1,10 @@
+FROM @ci_docker@
+ENV container docker
+
+ADD tests/ci-install.sh /ci-install.sh
+RUN ci_suite="@ci_suite@" ci_distro="@ci_distro@" ci_in_docker=yes /ci-install.sh
+
+ADD . /home/user/ci
+RUN chown -R user:user /home/user/ci
+WORKDIR /home/user/ci
+USER user

--- a/tests/ci-build.sh
+++ b/tests/ci-build.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Copyright © 2015-2018 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+set -x
+
+NULL=
+
+# ci_distro:
+# OS distribution in which we are testing
+# Typical values: ubuntu, debian; maybe fedora in future
+: "${ci_distro:=ubuntu}"
+
+# ci_docker:
+# If non-empty, this is the name of a Docker image. ci-install.sh will
+# fetch it with "docker pull" and use it as a base for a new Docker image
+# named "ci-image" in which we will do our testing.
+#
+# If empty, we test on "bare metal".
+# Typical values: ubuntu:xenial, debian:jessie-slim
+: "${ci_docker:=}"
+
+# ci_parallel:
+# A number of parallel jobs, passed to make -j
+: "${ci_parallel:=1}"
+
+# ci_sudo:
+# If yes, assume we can get root using sudo; if no, only use current user
+: "${ci_sudo:=no}"
+
+# ci_suite:
+# OS suite (release, branch) in which we are testing.
+# Typical values for ci_distro=debian: sid, jessie
+# Typical values for ci_distro=fedora might be 25, rawhide
+: "${ci_suite:=xenial}"
+
+# ci_test:
+# If yes, run tests; if no, just build
+: "${ci_test:=yes}"
+
+# ci_test_fatal:
+# If yes, test failures break the build; if no, they are reported but ignored
+: "${ci_test_fatal:=yes}"
+
+# ci_variant:
+# debug or production
+: "${ci_variant:=debug}"
+
+if [ -n "$ci_docker" ]; then
+    exec docker run \
+        --env=ci_docker="" \
+        --env=ci_parallel="${ci_parallel}" \
+        --env=ci_sudo=yes \
+        --env=ci_test="${ci_test}" \
+        --env=ci_test_fatal="${ci_test_fatal}" \
+        --env=ci_variant="${ci_variant}" \
+        --privileged \
+        ci-image \
+        tests/ci-build.sh
+fi
+
+maybe_fail_tests () {
+    if [ "$ci_test_fatal" = yes ]; then
+        exit 1
+    fi
+}
+
+NOCONFIGURE=1 ./autogen.sh
+
+srcdir="$(pwd)"
+mkdir ci-build
+cd ci-build
+
+make="make -j${ci_parallel} V=1 VERBOSE=1"
+
+case "$ci_variant" in
+    (debug)
+        set -- "$@" CFLAGS="-fsanitize=address -fsanitize=undefined -fPIE -pie"
+        ;;
+
+    (*)
+        ;;
+esac
+
+set -- "$@" --enable-installed-tests --enable-always-build-tests
+
+../configure "$@"
+
+${make}
+[ "$ci_test" = no ] || ${make} check || maybe_fail_tests
+cat test-suite.log || :
+[ "$ci_test" = no ] || ${make} distcheck || maybe_fail_tests
+
+${make} install DESTDIR=$(pwd)/DESTDIR
+( cd DESTDIR && find . -ls )
+
+if [ "$ci_sudo" = yes ] && [ "$ci_test" = yes ]; then
+    sudo ${make} install
+    LD_LIBRARY_PATH=/usr/local/lib ${make} installcheck || \
+        maybe_fail_tests
+    cat test-suite.log || :
+
+    env LD_LIBRARY_PATH=/usr/local/lib \
+    gnome-desktop-testing-runner -d /usr/local/share xdg-dbus-proxy/ || \
+        maybe_fail_tests
+fi
+
+# vim:set sw=4 sts=4 et:

--- a/tests/ci-install.sh
+++ b/tests/ci-install.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Copyright © 2015-2018 Collabora Ltd.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+set -euo pipefail
+set -x
+
+NULL=
+
+# ci_distro:
+# OS distribution in which we are testing
+# Typical values: ubuntu, debian; maybe fedora in future
+: "${ci_distro:=ubuntu}"
+
+# ci_docker:
+# If non-empty, this is the name of a Docker image. ci-install.sh will
+# fetch it with "docker pull" and use it as a base for a new Docker image
+# named "ci-image" in which we will do our testing.
+: "${ci_docker:=}"
+
+# ci_in_docker:
+# Used internally by ci-install.sh. If yes, we are inside the Docker image
+# (ci_docker is empty in this case).
+: "${ci_in_docker:=no}"
+
+# ci_suite:
+# OS suite (release, branch) in which we are testing.
+# Typical values for ci_distro=debian: sid, jessie
+# Typical values for ci_distro=fedora might be 25, rawhide
+: "${ci_suite:=xenial}"
+
+if [ $(id -u) = 0 ]; then
+    sudo=
+else
+    sudo=sudo
+fi
+
+if [ -n "$ci_docker" ]; then
+    sed \
+        -e "s/@ci_distro@/${ci_distro}/" \
+        -e "s/@ci_docker@/${ci_docker}/" \
+        -e "s/@ci_suite@/${ci_suite}/" \
+        < tests/ci-Dockerfile.in > Dockerfile
+    exec docker build -t ci-image .
+fi
+
+case "$ci_distro" in
+    (debian|ubuntu)
+        # Don't ask questions, just do it
+        sudo="$sudo env DEBIAN_FRONTEND=noninteractive"
+
+        $sudo apt-get -qq -y update
+        $sudo apt-get -qq -y --no-install-recommends install \
+            autoconf \
+            autoconf-archive \
+            automake \
+            autotools-dev \
+            ccache \
+            dbus \
+            docbook-xml \
+            docbook-xsl \
+            gnome-desktop-testing \
+            libglib2.0-dev \
+            libtool \
+            make \
+            sudo \
+            wget \
+            xsltproc \
+            xz-utils \
+            ${NULL}
+
+        if [ "$ci_in_docker" = yes ]; then
+            # Add the user that we will use to do the build inside the
+            # Docker container, and let them use sudo
+            adduser --disabled-password --gecos "" user
+            echo "user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nopasswd
+            chmod 0440 /etc/sudoers.d/nopasswd
+        fi
+
+        case "$ci_suite" in
+            (trusty|jessie|xenial)
+                # autoconf-archive in Debian 8 and Ubuntu <= 16.04 is too old,
+                # use the one from Debian 9 instead
+                wget http://deb.debian.org/debian/pool/main/a/autoconf-archive/autoconf-archive_20160916-1_all.deb
+                $sudo dpkg -i autoconf-archive_*_all.deb
+                rm autoconf-archive_*_all.deb
+                ;;
+        esac
+        ;;
+
+    (*)
+        echo "Don't know how to set up ${ci_distro}" >&2
+        exit 1
+        ;;
+esac
+
+# vim:set sw=4 sts=4 et:

--- a/tests/test-proxy.c
+++ b/tests/test-proxy.c
@@ -68,7 +68,6 @@ setup (Fixture *f,
                                                 "--session",
                                                 "--print-address=1",
                                                 "--nofork",
-                                                "--nosyslog",
                                                 NULL);
   g_assert_no_error (error);
   g_assert_nonnull (f->dbus_daemon);

--- a/tests/test-proxy.c
+++ b/tests/test-proxy.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <string.h>
 
 #include <glib.h>
 #include <glib-unix.h>

--- a/tests/test-proxy.c
+++ b/tests/test-proxy.c
@@ -27,6 +27,8 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 
+#include "backport-autoptr.h"
+
 #define DBUS_SERVICE_DBUS "org.freedesktop.DBus"
 #define DBUS_PATH_DBUS "/org/freedesktop/DBus"
 #define DBUS_INTERFACE_DBUS "org.freedesktop.DBus"


### PR DESCRIPTION
This complements #6 by adding test coverage on various distros of varying age, including Ubuntu 14.04 (GLib 2.40, which is the oldest we can reasonably support at the moment).

If the baseline distribution is meant to be newer than that, we can adjust the suites used: Debian releases and Ubuntu LTS releases are about a year apart, so we can easily hit about 50% of possible GLib branches.

The scripts in tests/ are reasonably CI-system-agnostic and should be feasible to hook up to Gitlab-CI or similar if desired (as has been done in dbus). It should also be reasonably straightforward to build
in a non-Debian-derived container by adding an alternative code path alongside the various apt-get calls.

If this is merged, contributors can enable Travis-CI for their forks even if it isn't enabled for the upstream repository, but ideally someone would enable Travis-CI for the upstream repository too.

This PR includes all the commits from #6, so please review that one first.