### PR TITLE
Fix musl compilation by adding TEMP_FAILURE_RETRY

### DIFF
--- a/dbus-proxy.c
+++ b/dbus-proxy.c
@@ -30,6 +30,15 @@
 #include <errno.h>
 
 #include "flatpak-proxy.h"
+// Taken from glibc unistd.h
+#ifndef TEMP_FAILURE_RETRY
+# define TEMP_FAILURE_RETRY(expression) \
+  (__extension__                                                              \
+    ({ long int __result;                                                     \
+       do __result = (long int) (expression);                                 \
+       while (__result == -1L && errno == EINTR);                             \
+       __result; }))
+#endif
 
 static const char *argv0;
 static GList *proxies;


### PR DESCRIPTION
Taken from https://github.com/void-linux/void-packages/blob/master/srcpkgs/xdg-dbus-proxy/patches/musl.patch .