### PR TITLE
Allow connecting from clients with different user id

### DIFF
--- a/Makefile-docs.am
+++ b/Makefile-docs.am
@@ -1,7 +1,6 @@
 XSLTPROC = xsltproc
 
 XSLTPROC_FLAGS = \
-	--nonet \
 	--stringparam man.output.quietly 1 \
 	--stringparam funcsynopsis.style ansi \
 	--stringparam man.th.extra1.suppress 1 \

--- a/README.md
+++ b/README.md
@@ -4,3 +4,32 @@ xdg-dbus-proxy
 xdg-dbus-proxy is a filtering proxy for D-Bus connections. It was originally
 part of the flatpak project, but it has been broken out as a standalone module
 to facilitate using it in other contexts.
+
+Building
+--------
+
+You need to have autotools installed. On Debian, don't forget to install 
+`autoconf-archive` too.
+
+- Run `./autogen.sh`. It will generate configure script and Makefile
+- Run `./configure` (see `./configure --help` for additional options)
+- Run `make`
+- Run `make install`
+
+To build debug version you can add flags to make, for example: 
+
+	make -e CFLAGS="-g -O0 -fsanitize=address" LDFLAGS="-fsanitize=address"
+
+Usage example
+-------------
+
+Start proxy with:
+
+	xdg-dbus-proxy "$DBUS_SESSION_BUS_ADDRESS" /tmp/proxy.socket --log 
+
+Test it using: 
+
+	DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/proxy.socket dbus-send --session --dest=org.freedesktop.DBus --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames
+
+This will display a list of D-Bus names visible through the proxy. You can 
+also use programs like D-Feet to examine the bus.

--- a/flatpak-proxy.h
+++ b/flatpak-proxy.h
@@ -61,6 +61,9 @@ void         flatpak_proxy_add_broadcast_rule (FlatpakProxy *proxy,
                                                const char   *name,
                                                gboolean      name_is_subtree,
                                                const char   *rule);
+void         flatpak_proxy_set_accepted_uids (FlatpakProxy *proxy,
+                                          GArray* uids);
+
 gboolean     flatpak_proxy_start (FlatpakProxy *proxy,
                                   GError      **error);
 void         flatpak_proxy_stop (FlatpakProxy *proxy);

--- a/xdg-dbus-proxy.xml
+++ b/xdg-dbus-proxy.xml
@@ -45,12 +45,16 @@
 </para>
 <refsect2><title>Basic Operation</title>
 <para>
-  The proxy listens to the unix domain socket at <replaceable>PATH</replaceable>,
+  The proxy listens to the unix domain socket at <replaceable>PATH</replaceable> (can look like /tmp/proxy.socket),
   and for each client that connects to the socket, it opens up a new connection to
-  the specified D-Bus <replaceable>ADDRESS</replaceable> (typically the session bus)
-  and forwards data between the two. During the authentication phase all data is
+  the specified D-Bus <replaceable>ADDRESS</replaceable> (typically the session bus, 
+  can look like unix:path=/var/run/1000/dbus.socket)
+  and forwards data between the two. During the authentication phase most data is
   forwarded as received, and additionally for the first 1 byte zero we also send
-  the proxy credentials to the bus.
+  the proxy credentials to the bus. Proxy always rewrites client's user id 
+  in <term>AUTH EXTERNAL </term> command to proxy's effective user id. Without this
+  DBus server would reject connection coming from one user id, but trying to 
+  authenticate as another user id.
 </para>
 <para>
   Once the connection is authenticated there are two modes, filtered and unfiltered.
@@ -206,6 +210,10 @@
     <varlistentry>
       <term><option>--broadcast=<replaceable>NAME</replaceable>=<replaceable>RULE</replaceable></option></term>
       <listitem><para>Set a rule for broadcast signals from the given name.</para></listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>--accept-uids=<replaceable>UID1,UID2,...</replaceable></option></term>
+      <listitem><para>Accept only connections made by processes with given effective user ids.</para></listitem>
     </varlistentry>
   </variablelist>
 </refsect1>


### PR DESCRIPTION
When client and proxy have different user ids, client cannot authenticate itself to the bus. The reason for this is that client sends an auth message with its user id, for example:

    AUTH EXTERNAL 31303030\r\n

(this is hex-encoded string "1000"). Proxy passes this message to DBus server vebratim, but the server sees that user id doesn't match proxy's user id and rejects connection. 

This can be tested by running a test command like this one:

    DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/proxy.socket dbus-send --session --dest=org.freedesktop.DBus --print-reply /org/freedesktop/DBus org.freedesktop.DBus.ListNames

There will be connection error.

To fix it, I have changed the code so that the proxy can rewrite user's id in `AUTH EXTERNAL` line with proxy's user id. This way, clients with different user id are able to connect to the bus.

I also had to refactor code a little for better readability. Now the proxy parses and splits auth messages so if it will be necessary, further processing is possible. When `--log` option is used, auth messages now are printed which should aid debugging issues.

I also have added a CLI argument to allow whitelisting user ids that are able to connect to the proxy.

I have tested my changes using additional [Python script](https://gist.github.com/codedokode/12d852f999c35fd73ff892a3b2c19279) which sends different types of messages, including sending messages byte-by-byte and filling messages with garbage to test that proxy doesn't crash. I used a build compiled with ASAN (address sanitizer) to make sure that there are no issues with invalid pointer usage.

I don't know if I can add this script to repository as it is not an automated but manual test.

I have also verified that there are no memory leaks by using heaptrack and connecting/disconnecting to proxy thousand times.
