### PR TITLE
fix: null point exception

### DIFF
--- a/dbus-proxy.c
+++ b/dbus-proxy.c
@@ -346,7 +346,10 @@ start_proxy (GPtrArray *args, int *args_i)
 
   if (!flatpak_proxy_start (proxy, &error))
     {
-      g_printerr ("Failed to start proxy for %s: %s\n", bus_address, error->message);
+      if (error != NULL)
+        {
+          g_printerr ("Failed to start proxy for %s: %s\n", bus_address, error->message);
+        }
       return FALSE;
     }
 


### PR DESCRIPTION
debug the command as follows can cause a null pointer exception
xdg-dbus-proxy --fd=26 unix:path=/run/usr/1000/bus
       /run/usr/1000/.dbus-proxy/session-bus-proxy --filter --own=org.gnome.ghex.*
       --talk=ca.desrt.dconf --call=org.freedesktop.portal.*=*
       --broadcast=org.freedesktop.portal.*=@/org/freedesktop/portal/*
      in my system, There is no .dbus-proxy folder in the /run/usr/1000/ directory,  xdg-dbus-proxy 0.1.1-1
Log: