### PR TITLE
Add a Meson build system

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   check:
-    name: Build with gcc and test
+    name: Build with Autotools and gcc, and test
     runs-on: ubuntu-18.04
     steps:
     - name: Install Dependencies
@@ -80,6 +80,69 @@ jobs:
     - name: distcheck
       run: |
         make -C _build -j $(getconf _NPROCESSORS_ONLN) distcheck VERBOSE=1
+
+  meson:
+    name: Build with Meson and gcc, and test
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Dependencies
+      run: |
+        sudo add-apt-repository 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main' # Needed for updates to work
+        sudo apt-get update
+        sudo apt-get install -y \
+          dbus \
+          docbook-xml \
+          docbook-xsl \
+          libglib2.0-dev \
+          meson \
+          xsltproc \
+          ${NULL+}
+    - name: Check out xdg-dbus-proxy
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Create logs dir
+      run: mkdir test-logs
+    - name: configure
+      run: |
+        meson _build -Db_sanitize=address,undefined
+    - name: Build xdg-dbus-proxy
+      run: ninja -C _build -v
+    - name: Run tests
+      run: meson test -C _build -v
+    - name: Collect overall test logs on failure
+      if: failure()
+      run: mv _build/meson-logs/testlog.txt test-logs/ || true
+    - name: Collect individual test logs on cancel
+      if: failure() || cancelled()
+      run: mv _build/meson-logs/testlog.txt test-logs/ || true
+    - name: install
+      run: |
+        DESTDIR="$(pwd)/DESTDIR" meson install -C _build
+        ( cd DESTDIR && find -ls )
+    - name: distcheck
+      run: |
+        meson dist -C _build
+    - name: Collect dist test logs on failure
+      if: failure()
+      run: mv _build/meson-private/dist-build/meson-logs/testlog.txt test-logs/disttestlog.txt || true
+    - name: use as subproject
+      run: |
+        mkdir tests/use-as-subproject/subprojects
+        tar -C tests/use-as-subproject/subprojects -xf _build/meson-dist/xdg-dbus-proxy-*.tar.xz
+        mv tests/use-as-subproject/subprojects/xdg-dbus-proxy-* tests/use-as-subproject/subprojects/dbus-proxy
+        ( cd tests/use-as-subproject && meson _build )
+        ninja -C tests/use-as-subproject/_build -v
+        meson test -C tests/use-as-subproject/_build
+        DESTDIR="$(pwd)/DESTDIR-as-subproject" meson install -C tests/use-as-subproject/_build
+        ( cd DESTDIR-as-subproject && find -ls )
+        test -x DESTDIR-as-subproject/usr/local/libexec/notflatpak-dbus-proxy
+    - name: Upload test logs
+      uses: actions/upload-artifact@v1
+      if: failure() || cancelled()
+      with:
+        name: test logs
+        path: test-logs
 
   clang:
     name: Build with clang and analyze

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,8 @@ include tests/Makefile.am.inc
 
 EXTRA_DIST += build-aux/glib-tap.mk
 EXTRA_DIST += build-aux/tap-test
+EXTRA_DIST += meson.build
+EXTRA_DIST += meson_options.txt
 
 # Add rules for code-coverage testing, as defined by AX_CODE_COVERAGE
 include $(top_srcdir)/aminclude_static.am

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,90 @@
+project(
+  'xdg-dbus-proxy',
+  'c',
+  version : '0.1.3',
+  meson_version : '>=0.49.0',
+  default_options : [
+    'warning_level=2',
+  ],
+)
+
+cc = meson.get_compiler('c')
+add_project_arguments('-D_GNU_SOURCE', language : 'c')
+common_include_directories = include_directories('.')
+
+add_project_arguments(
+  cc.get_supported_arguments([
+    # Deliberately not warning about this, ability to zero-initialize
+    # a struct is a feature
+    '-Wno-missing-field-initializers',
+    '-Wno-error=missing-field-initializers',
+
+    # Deliberately not warning about this, unused parameters to a callback
+    # are not a bug
+    '-Wno-unused-parameter',
+    '-Wno-error=unused-parameter',
+  ]),
+  language : 'c',
+)
+
+glib_dep = dependency('glib-2.0', version : '>=2.40')
+gio_dep = dependency('gio-2.0', version : '>=2.40')
+gio_unix_dep = dependency('gio-unix-2.0', version : '>=2.40')
+common_deps = [glib_dep, gio_dep, gio_unix_dep]
+
+if meson.is_subproject()
+  bindir = get_option('libexecdir')
+
+  if get_option('program_prefix') == ''
+    error('program_prefix option must be set when xdg-dbus-proxy is a subproject')
+  endif
+
+  exe_name = get_option('program_prefix') + 'dbus-proxy'
+else
+  bindir = get_option('bindir')
+  exe_name = 'xdg-dbus-proxy'
+endif
+
+conf_data = configuration_data()
+conf_data.set_quoted('BINDIR', get_option('prefix') / bindir)
+conf_data.set_quoted('PACKAGE_NAME', meson.project_name())
+conf_data.set_quoted('PACKAGE_VERSION', meson.project_version())
+configure_file(output : 'config.h',
+               configuration : conf_data)
+
+dbus_proxy = executable(
+  exe_name,
+  [
+    'dbus-proxy.c',
+    'flatpak-proxy.c',
+  ],
+  install : true,
+  install_dir : bindir,
+  dependencies : common_deps,
+)
+
+xsltproc = find_program('xsltproc', required : get_option('man'))
+
+if xsltproc.found() and not meson.is_subproject()
+  custom_target(
+    'xdg-dbus-proxy.1',
+    output : 'xdg-dbus-proxy.1',
+    input : 'xdg-dbus-proxy.xml',
+    command : [
+      xsltproc,
+      '--nonet',
+      '--stringparam', 'man.output.quietly', '1',
+      '--stringparam', 'funcsynopsis.style', 'ansi',
+      '--stringparam', 'man.th.extra1.suppress', '1',
+      '--stringparam', 'man.authors.section.enabled', '0',
+      '--stringparam', 'man.copyright.section.enabled', '0',
+      '-o', '@OUTPUT@',
+      'http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl',
+      '@INPUT@',
+    ],
+    install : true,
+    install_dir : get_option('mandir') / 'man1',
+  )
+endif
+
+subdir('tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,12 @@
+option(
+  'man',
+  type : 'feature',
+  description : 'generate man pages',
+  value : 'auto',
+)
+option(
+  'program_prefix',
+  type : 'string',
+  description : 'Prepend string to executable name, for use with subprojects',
+  value : '',
+)

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -11,3 +11,9 @@ test_programs = \
 test_proxy_CPPFLAGS = -DBINDIR=\"$(bindir)\"
 test_proxy_SOURCES = tests/test-proxy.c
 test_proxy_LDADD = $(COMMON_LIBS)
+
+EXTRA_DIST += tests/meson.build
+EXTRA_DIST += tests/use-as-subproject/README
+EXTRA_DIST += tests/use-as-subproject/config.h
+EXTRA_DIST += tests/use-as-subproject/dummy-config.h.in
+EXTRA_DIST += tests/use-as-subproject/meson.build

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,35 @@
+test_programs = [
+  [
+    'test-proxy',
+    executable(
+      'test-proxy',
+      'test-proxy.c',
+      dependencies : common_deps,
+      include_directories : common_include_directories,
+    ),
+  ],
+]
+
+test_env = environment()
+test_env.set('DBUS_PROXY', dbus_proxy.full_path())
+test_env.set('G_TEST_BUILDDIR', meson.current_build_dir())
+test_env.set('G_TEST_SRCDIR', meson.current_source_dir())
+
+foreach pair : test_programs
+  name = pair[0]
+  test_program = pair[1]
+  if meson.version().version_compare('>=0.50.0')
+    test(
+      name,
+      test_program,
+      env : test_env,
+      protocol : 'tap',
+    )
+  else
+    test(
+      name,
+      test_program,
+      env : test_env,
+    )
+  endif
+endforeach

--- a/tests/use-as-subproject/.gitignore
+++ b/tests/use-as-subproject/.gitignore
@@ -1,0 +1,2 @@
+/_build/
+/subprojects/

--- a/tests/use-as-subproject/README
+++ b/tests/use-as-subproject/README
@@ -1,0 +1,3 @@
+This is a simple example of a project that uses xdg-dbus-proxy as a
+subproject. The intention is that if this project can successfully build
+xdg-dbus-proxy as a subproject, then so could Flatpak.

--- a/tests/use-as-subproject/config.h
+++ b/tests/use-as-subproject/config.h
@@ -1,0 +1,1 @@
+#error Should not use superproject config.h to compile xdg-dbus-proxy

--- a/tests/use-as-subproject/dummy-config.h.in
+++ b/tests/use-as-subproject/dummy-config.h.in
@@ -1,0 +1,1 @@
+#error Should not use superproject generated config.h to compile xdg-dbus-proxy

--- a/tests/use-as-subproject/meson.build
+++ b/tests/use-as-subproject/meson.build
@@ -1,0 +1,19 @@
+project(
+  'use-xdg-dbus-proxy-as-subproject',
+  'c',
+  version : '0',
+  meson_version : '>=0.49.0',
+)
+
+configure_file(
+  output : 'config.h',
+  input : 'dummy-config.h.in',
+  configuration : configuration_data(),
+)
+
+subproject(
+  'dbus-proxy',
+  default_options : [
+    'program_prefix=notflatpak-',
+  ],
+)


### PR DESCRIPTION
This allows xdg-dbus-proxy to be built as a subproject in larger Meson
projects. When built as a subproject, we install into the --libexecdir
and require a program prefix to be specified: for example, Flatpak would
use program_prefix=flatpak- to get /usr/libexec/flatpak-dbus-proxy.