### PR TITLE
flatpak-proxy: Fix unintended fallthrough

### DIFF
--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -2358,8 +2358,10 @@ got_buffer_from_bus (FlatpakProxyClient *client, ProxySide *side, Buffer *buffer
                 {
                   g_autofree char *my_id = get_arg0_string (buffer);
                   flatpak_proxy_client_update_unique_id_policy (client, my_id, FLATPAK_POLICY_TALK);
-                  break;
                 }
+              /* ... else it's an ERROR or something. Either way, pass it
+               * through to the client unedited. */
+              break;
 
             case EXPECTED_REPLY_REWRITE:
               /* Replace a roundtrip ping with the rewritten message */


### PR DESCRIPTION
If the reply to Hello() is an error (or some other non-reply), we don't
want to fall through to EXPECTED_REPLY_REWRITE. Treat it like
EXPECTED_REPLY_NORMAL instead.

---

Detected by enabling more warnings during #31.