### PR TITLE
Fix various compiler warnings

### DIFF
--- a/dbus-proxy.c
+++ b/dbus-proxy.c
@@ -158,7 +158,7 @@ add_args (GBytes    *bytes,
 
 
 static gboolean
-parse_generic_args (GPtrArray *args, int *args_i)
+parse_generic_args (GPtrArray *args, guint *args_i)
 {
   const char *arg = g_ptr_array_index (args, *args_i);
 
@@ -226,7 +226,7 @@ parse_generic_args (GPtrArray *args, int *args_i)
 }
 
 static gboolean
-start_proxy (GPtrArray *args, int *args_i)
+start_proxy (GPtrArray *args, guint *args_i)
 {
   g_autoptr(FlatpakProxy) proxy = NULL;
   g_autoptr(GError) error = NULL;
@@ -374,7 +374,8 @@ main (int argc, const char *argv[])
 {
   g_autoptr(GPtrArray) args = NULL;
   GMainLoop *service_loop;
-  int i, args_i;
+  int i;
+  guint args_i;
 
   setlocale (LC_ALL, "");
 

--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -2358,8 +2358,10 @@ got_buffer_from_bus (FlatpakProxyClient *client, ProxySide *side, Buffer *buffer
                 {
                   g_autofree char *my_id = get_arg0_string (buffer);
                   flatpak_proxy_client_update_unique_id_policy (client, my_id, FLATPAK_POLICY_TALK);
-                  break;
                 }
+              /* ... else it's an ERROR or something. Either way, pass it
+               * through to the client unedited. */
+              break;
 
             case EXPECTED_REPLY_REWRITE:
               /* Replace a roundtrip ping with the rewritten message */

--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -29,6 +29,10 @@
 #include <gio/gunixconnection.h>
 #include <gio/gunixfdmessage.h>
 
+#if !GLIB_CHECK_VERSION(2, 58, 0)
+# define G_SOURCE_FUNC(f) ((GSourceFunc) (void (*)(void)) (f))
+#endif
+
 /**
  * The proxy listens to a unix domain socket, and for each new
  * connection it opens up a new connection to a specified dbus bus
@@ -1046,7 +1050,7 @@ queue_outgoing_buffer (ProxySide *side, Buffer *buffer)
 
       socket = g_socket_connection_get_socket (side->connection);
       side->out_source = g_socket_create_source (socket, G_IO_OUT, NULL);
-      g_source_set_callback (side->out_source, (GSourceFunc) side_out_cb, side, NULL);
+      g_source_set_callback (side->out_source, G_SOURCE_FUNC (side_out_cb), side, NULL);
       g_source_attach (side->out_source, NULL);
       g_source_unref (side->out_source);
     }
@@ -2725,7 +2729,7 @@ start_reading (ProxySide *side)
 
   socket = g_socket_connection_get_socket (side->connection);
   side->in_source = g_socket_create_source (socket, G_IO_IN, NULL);
-  g_source_set_callback (side->in_source, (GSourceFunc) side_in_cb, side, NULL);
+  g_source_set_callback (side->in_source, G_SOURCE_FUNC (side_in_cb), side, NULL);
   g_source_attach (side->in_source, NULL);
   g_source_unref (side->in_source);
 }

--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -2349,17 +2349,15 @@ got_buffer_from_bus (FlatpakProxyClient *client, ProxySide *side, Buffer *buffer
         {
           expected_reply = steal_expected_reply (get_other_side (side), header->reply_serial);
 
-          /* We only allow replies we expect */
-          if (expected_reply == EXPECTED_REPLY_NONE)
+          switch (expected_reply)
             {
+            case EXPECTED_REPLY_NONE:
+              /* We only allow replies we expect */
               if (client->proxy->log_messages)
                 g_print ("*Unexpected reply*\n");
               buffer_unref (buffer);
               return;
-            }
 
-          switch (expected_reply)
-            {
             case EXPECTED_REPLY_HELLO:
               /* When we get the initial reply to Hello, allow all
                  further communications to our own unique id. */

--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -1785,6 +1785,13 @@ policy_from_handler (BusHandler handler)
     case HANDLE_VALIDATE_SEE:
       return FLATPAK_POLICY_SEE;
 
+    case HANDLE_DENY:
+    case HANDLE_FILTER_GET_OWNER_REPLY:
+    case HANDLE_FILTER_HAS_OWNER_REPLY:
+    case HANDLE_FILTER_NAME_LIST_REPLY:
+    case HANDLE_HIDE:
+    case HANDLE_PASS:
+    case HANDLE_VALIDATE_MATCH:
     default:
       return FLATPAK_POLICY_NONE;
     }

--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,23 @@ common_include_directories = include_directories('.')
 
 add_project_arguments(
   cc.get_supported_arguments([
+    '-Werror=aggregate-return',
+    '-Werror=empty-body',
+    '-Werror=implicit-function-declaration',
+    '-Werror=incompatible-pointer-types',
+    '-Werror=init-self',
+    '-Werror=int-conversion',
+    '-Werror=misleading-indentation',
+    '-Werror=missing-declarations',
+    '-Werror=missing-include-dirs',
+    '-Werror=missing-prototypes',
+    '-Werror=overflow',
+    '-Werror=parenthesis',
+    '-Werror=pointer-arith',
+    '-Werror=return-type',
+    '-Werror=shadow',
+    '-Werror=strict-prototypes',
+
     # Deliberately not warning about this, ability to zero-initialize
     # a struct is a feature
     '-Wno-missing-field-initializers',

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,8 @@ add_project_arguments(
     '-Werror=return-type',
     '-Werror=shadow',
     '-Werror=strict-prototypes',
+    '-Werror=switch-default',
+    '-Wswitch-enum',
 
     # Deliberately not warning about this, ability to zero-initialize
     # a struct is a feature


### PR DESCRIPTION
Includes #32, which is the only compiler warning that seemed like it indicated a genuine bug; please review that one first.

* #32

* dbus-proxy: Treat GPtrArray index as unsigned
    
    This squashes some -Wsign-compare warnings.

* buffer_read: Be more careful with signedness

* flatpak-proxy: Silence compiler warnings about invalid casts
    
    GSource and -Wcast-function-type don't really get on, but G_SOURCE_FUNC
    has the appropriate magic to stop the compiler warning about this cast.

* flatpak-proxy: Move a case from an if() into a switch()
    
    Instead of special-casing EXPECTED_REPLY_NONE to be a separate if()
    block, treating it as part of the switch() lets us use -Wswitch-enum
    to warn if we have missed one.

* flatpak-proxy: Handle every case in a switch
    
    This lets us use -Wswitch-enum to detect when we've missed one.

* build: Add some more compiler warnings
    
    Taken from ostree, via bubblewrap.

* build: Add switch warnings