### PR TITLE
remove meaningless and redundant code

### DIFF
--- a/dbus-proxy.c
+++ b/dbus-proxy.c
@@ -366,7 +366,6 @@ sync_closed_cb (GIOChannel  *source,
     flatpak_proxy_stop (FLATPAK_PROXY (l->data));
 
   exit (0);
-  return TRUE;
 }
 
 int


### PR DESCRIPTION
function sync_closed_cb  "return TRUE" is meaningless and redundant, code style should consistent with elsewhere, ie:  in function parse_generic_args   exit without return value