### PR TITLE
Add an option to disable build-time tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,4 +87,6 @@ if xsltproc.found() and not meson.is_subproject()
   )
 endif
 
-subdir('tests')
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,3 +10,9 @@ option(
   description : 'Prepend string to executable name, for use with subprojects',
   value : '',
 )
+option(
+  'tests',
+  type : 'boolean',
+  description : 'Build and run automated tests',
+  value : 'true',
+)


### PR DESCRIPTION
When using xdg-dbus-proxy as a subproject in Flatpak, we don't
necessarily want to run its unit tests as part of Flatpak's test
suite.

In particular, when bundling selected source code from xdg-dbus-proxy
into Flatpak `make dist` tarballs, it would be simpler if we could
avoid having to include the unit tests.