### PR TITLE
meson: Optionally install tests for "as-installed" testing

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,10 @@
 option(
+  'installed_tests',
+  type : 'boolean',
+  description : 'Build and install "as-installed" tests',
+  value : 'false',
+)
+option(
   'man',
   type : 'feature',
   description : 'generate man pages',

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -13,6 +13,7 @@ test_proxy_SOURCES = tests/test-proxy.c
 test_proxy_LDADD = $(COMMON_LIBS)
 
 EXTRA_DIST += tests/meson.build
+EXTRA_DIST += tests/tap.test.in
 EXTRA_DIST += tests/use-as-subproject/README
 EXTRA_DIST += tests/use-as-subproject/config.h
 EXTRA_DIST += tests/use-as-subproject/dummy-config.h.in

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,7 @@
+enable_installed_tests = get_option('installed_tests') and not meson.is_subproject()
+installed_testdir = get_option('libexecdir') / 'installed-tests' / meson.project_name()
+installed_tests_metadir = get_option('datadir') / 'installed-tests' / meson.project_name()
+
 test_programs = [
   [
     'test-proxy',
@@ -6,6 +10,8 @@ test_programs = [
       'test-proxy.c',
       dependencies : common_deps,
       include_directories : common_include_directories,
+      install : enable_installed_tests,
+      install_dir : installed_testdir,
     ),
   ],
 ]
@@ -30,6 +36,18 @@ foreach pair : test_programs
       name,
       test_program,
       env : test_env,
+    )
+  endif
+
+  if enable_installed_tests
+    configure_file(
+      input : 'tap.test.in',
+      output : name + '.test',
+      configuration : {
+        'basename' : name,
+        'installed_testdir' : get_option('prefix') / installed_testdir,
+      },
+      install_dir : installed_tests_metadir,
     )
   endif
 endforeach

--- a/tests/tap.test.in
+++ b/tests/tap.test.in
@@ -1,0 +1,4 @@
+[Test]
+Type=session
+Exec=@installed_testdir@/@basename@ --tap
+Output=TAP


### PR DESCRIPTION
This is used in the Debian packaging via ginsttest-runner and the
autopkgtest framework. Previously, it was supported by the Autotools
build system but not by the Meson build system.