### PR TITLE
flatpak-proxy: Fix D-Bus disconnection with overly long object paths

### DIFF
--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -1116,7 +1116,7 @@ get_signature (Buffer *buffer, guint32 *offset, guint32 end_offset)
 static const char *
 get_string (Buffer *buffer, Header *header, guint32 *offset, guint32 end_offset)
 {
-  guint8 len;
+  guint32 len;
   char *str;
 
   *offset = align_by_4 (*offset);


### PR DESCRIPTION
According to the D-Bus specifications: https://dbus.freedesktop.org/doc/dbus-specification.html#id-1.4.4
> For the STRING and OBJECT_PATH types, [the data length] is encoded in 4 bytes (a UINT32).

But the code was trying to parse the 32-bit integer as an 8-bit one, meaning that, as was the case with object paths created by the dLeyna project, a 259-byte long string would be parsed like a 3-byte long one.