### PR TITLE
meson: update deprecated syntax

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,7 +2,7 @@ option(
   'installed_tests',
   type : 'boolean',
   description : 'Build and install "as-installed" tests',
-  value : 'false',
+  value : false,
 )
 option(
   'man',
@@ -20,5 +20,5 @@ option(
   'tests',
   type : 'boolean',
   description : 'Build and run automated tests',
-  value : 'true',
+  value : true,
 )


### PR DESCRIPTION
When using meson 1.2.1, `meson build` prints:

    NOTICE: Future-deprecated features used:
     * 1.1.0: {'"boolean option" keyword argument "value" of type str'}

This patch defines the default values for boolean fields using the native boolean type and squelches this warning.