### PR TITLE
Don't require TALK permission for broadcast rules

### DIFF
--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -2744,11 +2744,11 @@ got_buffer_from_bus (FlatpakProxyClient *client, ProxySide *side, Buffer *buffer
           policy = flatpak_proxy_client_get_max_policy_and_matched (client, header->sender, &filters);
 
           if (policy == FLATPAK_POLICY_OWN ||
-              (policy == FLATPAK_POLICY_TALK &&
-               any_filter_matches (filters, FILTER_TYPE_BROADCAST,
-                                   header->path,
-                                   header->interface,
-                                   header->member)))
+              policy == FLATPAK_POLICY_TALK ||
+              any_filter_matches (filters, FILTER_TYPE_BROADCAST,
+                                  header->path,
+                                  header->interface,
+                                  header->member))
             filtered = FALSE;
 
           if (filtered)


### PR DESCRIPTION
The context is to allow for AT-SPI broadcast signals (specifically `EventListenerRegistered` and `EventListenerDeregistered` from the `org.a11y.atspi.Registry` interface on the registry object) to be allowed through, without giving apps a full talk permission to it.

CC @ebassi @smcv 

~@smcv I appreciate this goes directly against https://gitlab.freedesktop.org/dbus/dbus/-/issues/185#note_48128, but I don't understand that restriction and would appreciate some ellucidation as to why that's been proposed. I'm not particularly sold on this approach so any advice will be highly welcomed!~

Edit: see https://github.com/flatpak/xdg-dbus-proxy/pull/61#issuecomment-2134772967 for a more up-to-date understanding of the D-Bus issue.