### PR TITLE
ci: Use upload-artifact@v4 and require ubuntu 22.04 runners

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,6 @@ name: CI checks
 
 on:
   push:
-    branches:
-    - main
   pull_request:
     paths-ignore:
     - CODE_OF_CONDUCT.md
@@ -18,7 +16,7 @@ on:
 jobs:
   meson:
     name: Build with Meson and gcc, and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install Dependencies
       run: |
@@ -72,7 +70,7 @@ jobs:
         ( cd DESTDIR-as-subproject && find -ls )
         test -x DESTDIR-as-subproject/usr/local/libexec/notflatpak-dbus-proxy
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
         name: test logs
@@ -136,7 +134,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/meson-logs/testlog.txt test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
         name: test logs
@@ -145,7 +143,7 @@ jobs:
   valgrind:
     name: Run tests in valgrind
     needs: meson # Don't run expensive test if main check fails
-    runs-on: ubuntu-20.04 # Might as well test with a different one too
+    runs-on: ubuntu-22.04
     steps:
     - name: Install Dependencies
       run: |
@@ -185,7 +183,7 @@ jobs:
       if: failure() || cancelled()
       run: mv _build/meson-logs/testlog.txt test-logs/ || true
     - name: Upload test logs
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       if: failure() || cancelled()
       with:
         name: test logs


### PR DESCRIPTION
The upload-artifact@v1 action doesn't work anymore, and github has no ubuntu 20.04 runners anymore.