### PR TITLE
dbus-proxy: fix build with glibc >= 2.43

### DIFF
--- a/dbus-proxy.c
+++ b/dbus-proxy.c
@@ -133,7 +133,7 @@ add_args (GBytes    *bytes,
 {
   gsize data_len, remainder_len;
   const guchar *data = g_bytes_get_data (bytes, &data_len);
-  guchar *s;
+  const guchar *s;
   const guchar *remainder;
 
   remainder = data;


### PR DESCRIPTION
memchr() returns const void * when passed const input, but the result was assigned to guchar *. This triggers
-Wincompatible-pointer-types-discards-qualifiers when building with clang and -Werror.

Make the pointer const to preserve const correctness.

Closes: https://github.com/flatpak/xdg-dbus-proxy/issues/70