### PR TITLE
Add socket file descriptor support

### DIFF
--- a/dbus-proxy.c
+++ b/dbus-proxy.c
@@ -49,7 +49,7 @@ static void usage (int ecode, FILE *out) G_GNUC_NORETURN;
 static void
 usage (int ecode, FILE *out)
 {
-  fprintf (out, "usage: %s [OPTIONS...] [ADDRESS PATH [OPTIONS...] ...]\n\n", argv0);
+  fprintf (out, "usage: %s [OPTIONS...] [ADDRESS (PATH|fd:FD) [OPTIONS...] ...]\n\n", argv0);
 
   fprintf (out,
            "Options:\n"
@@ -232,6 +232,8 @@ start_proxy (GPtrArray *args, guint *args_i)
   g_autoptr(GError) error = NULL;
   const char *bus_address, *socket_path;
   const char *arg;
+  int socket_fd = -1;
+  int n = 0;
 
   if (*args_i >= args->len || ((char *) g_ptr_array_index (args, *args_i))[0] == '-')
     {
@@ -251,7 +253,21 @@ start_proxy (GPtrArray *args, guint *args_i)
   socket_path = g_ptr_array_index (args, *args_i);
   *args_i += 1;
 
-  proxy = flatpak_proxy_new (bus_address, socket_path);
+  if (g_str_has_prefix (socket_path, "fd:"))
+    {
+      if (sscanf (socket_path, "fd:%d%n", &socket_fd, &n) != 1 || 
+          socket_path[n] != '\0' ||
+          socket_fd < 3)
+        {
+          g_printerr ("Invalid fd: '%s'\n", socket_path);
+          return FALSE;
+        }
+      proxy = flatpak_proxy_new_from_fd (bus_address, socket_fd);
+    }
+  else
+    {
+      proxy = flatpak_proxy_new_from_path (bus_address, socket_path);
+    }
 
   while (*args_i < args->len)
     {

--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include <unistd.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "flatpak-proxy.h"
@@ -338,6 +339,7 @@ struct FlatpakProxy
 
   GList         *clients;
   char          *socket_path;
+  int            socket_fd;
   char          *dbus_address;
 
   gboolean       filter;
@@ -356,7 +358,8 @@ enum {
   PROP_0,
 
   PROP_DBUS_ADDRESS,
-  PROP_SOCKET_PATH
+  PROP_SOCKET_PATH,
+  PROP_SOCKET_FD,
 };
 
 #define FLATPAK_TYPE_PROXY flatpak_proxy_get_type ()
@@ -709,7 +712,7 @@ flatpak_proxy_finalize (GObject *object)
 {
   FlatpakProxy *proxy = FLATPAK_PROXY (object);
 
-  if (g_socket_service_is_active (G_SOCKET_SERVICE (proxy)))
+  if (g_socket_service_is_active (G_SOCKET_SERVICE (proxy)) && proxy->socket_path)
     unlink (proxy->socket_path);
 
   g_assert (proxy->clients == NULL);
@@ -740,6 +743,10 @@ flatpak_proxy_set_property (GObject      *object,
       proxy->socket_path = g_value_dup_string (value);
       break;
 
+    case PROP_SOCKET_FD:
+      proxy->socket_fd = g_value_get_int (value);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -762,6 +769,10 @@ flatpak_proxy_get_property (GObject    *object,
 
     case PROP_SOCKET_PATH:
       g_value_set_string (value, proxy->socket_path);
+      break;
+
+    case PROP_SOCKET_FD:
+      g_value_set_int (value, proxy->socket_fd);
       break;
 
     default:
@@ -3197,6 +3208,15 @@ flatpak_proxy_class_init (FlatpakProxyClass *klass)
                                                         "",
                                                         NULL,
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property (object_class,
+                                   PROP_SOCKET_FD,
+                                   g_param_spec_int ("socket-fd",
+                                                     "",
+                                                     "",
+                                                     -1,
+                                                     G_MAXINT,
+                                                     -1,
+                                                     G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
 }
 
@@ -3204,34 +3224,71 @@ FlatpakProxy *
 flatpak_proxy_new (const char *dbus_address,
                    const char *socket_path)
 {
-  FlatpakProxy *proxy;
+  return flatpak_proxy_new_from_path(dbus_address, socket_path);
+}
 
-  proxy = g_object_new (FLATPAK_TYPE_PROXY, "dbus-address", dbus_address, "socket-path", socket_path, NULL);
+FlatpakProxy *
+flatpak_proxy_new_from_path (const char *dbus_address,
+                             const char *socket_path)
+{
+  FlatpakProxy *proxy;
+  proxy = g_object_new (FLATPAK_TYPE_PROXY,
+                        "dbus-address", dbus_address,
+                        "socket-path", socket_path,
+                        NULL);
+  return proxy;
+}
+
+FlatpakProxy *
+flatpak_proxy_new_from_fd (const char *dbus_address,
+                           int         socket_fd)
+{
+  FlatpakProxy *proxy;
+  proxy = g_object_new (FLATPAK_TYPE_PROXY,
+                        "dbus-address", dbus_address,
+                        "socket-fd", socket_fd,
+                        NULL);
   return proxy;
 }
 
 gboolean
 flatpak_proxy_start (FlatpakProxy *proxy, GError **error)
 {
-  GSocketAddress *address;
   gboolean res;
 
-  unlink (proxy->socket_path);
+  if (proxy->socket_fd < 0)
+    {
+      g_autoptr(GSocketAddress) address = NULL;
 
-  address = g_unix_socket_address_new (proxy->socket_path);
+      unlink (proxy->socket_path);
+      address = g_unix_socket_address_new (proxy->socket_path);
 
-  res = g_socket_listener_add_address (G_SOCKET_LISTENER (proxy),
-                                       address,
-                                       G_SOCKET_TYPE_STREAM,
-                                       G_SOCKET_PROTOCOL_DEFAULT,
-                                       NULL, /* source_object */
-                                       NULL, /* effective_address */
-                                       error);
-  g_object_unref (address);
+      res = g_socket_listener_add_address (G_SOCKET_LISTENER (proxy),
+                                           address,
+                                           G_SOCKET_TYPE_STREAM,
+                                           G_SOCKET_PROTOCOL_DEFAULT,
+                                           NULL, /* source_object */
+                                           NULL, /* effective_address */
+                                           error);
+      if (!res)
+        return FALSE;
+    }
+  else
+    {
+      g_autoptr(GSocket) socket = NULL;
 
-  if (!res)
-    return FALSE;
+      socket = g_socket_new_from_fd (proxy->socket_fd, error);
 
+      if (socket == NULL)
+        return FALSE;
+
+      res = g_socket_listener_add_socket (G_SOCKET_LISTENER (proxy),
+                                          socket,
+                                          NULL, /* source_object */
+                                          error);
+      if (!res)
+        return FALSE;
+    }
 
   g_socket_service_start (G_SOCKET_SERVICE (proxy));
   return TRUE;
@@ -3240,7 +3297,8 @@ flatpak_proxy_start (FlatpakProxy *proxy, GError **error)
 void
 flatpak_proxy_stop (FlatpakProxy *proxy)
 {
-  unlink (proxy->socket_path);
+  if (proxy->socket_path)
+    unlink (proxy->socket_path);
 
   g_socket_service_stop (G_SOCKET_SERVICE (proxy));
 }

--- a/flatpak-proxy.h
+++ b/flatpak-proxy.h
@@ -43,6 +43,10 @@ GType flatpak_proxy_get_type (void);
 
 FlatpakProxy *flatpak_proxy_new (const char *dbus_address,
                                  const char *socket_path);
+FlatpakProxy *flatpak_proxy_new_from_path (const char *dbus_address,
+                                           const char *socket_path);
+FlatpakProxy *flatpak_proxy_new_from_fd (const char *dbus_address,
+                                         int         socket_fd);
 void         flatpak_proxy_set_log_messages (FlatpakProxy *proxy,
                                              gboolean      log);
 void         flatpak_proxy_set_filter (FlatpakProxy *proxy,

--- a/tests/test-proxy.c
+++ b/tests/test-proxy.c
@@ -21,6 +21,8 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 #include <unistd.h>
 
 #include <glib.h>
@@ -45,12 +47,17 @@ typedef struct
   gchar *proxy_address;
   const gchar *proxy_path;
   int sync_pipe;
+  int listen_fd;
 } Fixture;
 
 typedef struct
 {
   int dummy;
 } Config;
+
+typedef struct {
+  gboolean use_fd_arg;
+} TestParams;
 
 static void
 setup (Fixture *f,
@@ -62,6 +69,7 @@ setup (Fixture *f,
   gchar address_buffer[4096] = { 0 };
   g_autofree gchar *escaped = NULL;
   char *newline;
+  struct sockaddr_un addr;
 
   f->sync_pipe = -1;
 
@@ -112,6 +120,16 @@ setup (Fixture *f,
   f->proxy_socket = g_build_filename (f->temp_directory, "proxy", NULL);
   escaped = g_dbus_address_escape_value (f->proxy_socket);
   f->proxy_address = g_strdup_printf ("unix:path=%s", escaped);
+
+  f->listen_fd = socket (AF_UNIX, SOCK_STREAM, 0);
+  g_assert_cmpint (f->listen_fd, >=, 0);
+
+  memset (&addr, 0, sizeof (addr));
+  addr.sun_family = AF_UNIX;
+  strncpy (addr.sun_path, f->proxy_socket, sizeof (addr.sun_path) - 1);
+
+  g_assert_cmpint (bind (f->listen_fd, (struct sockaddr *) &addr, sizeof (addr)), ==, 0);
+  g_assert_cmpint (listen (f->listen_fd, 1), ==, 0);
 }
 
 enum
@@ -123,7 +141,7 @@ enum
 
 static void
 test_basics (Fixture *f,
-             gconstpointer context G_GNUC_UNUSED)
+             gconstpointer context)
 {
   g_autoptr(GSubprocessLauncher) launcher = NULL;
   g_autoptr(GError) error = NULL;
@@ -135,6 +153,7 @@ test_basics (Fixture *f,
   ssize_t bytes_read;
   gsize i;
   gboolean found;
+  const TestParams *params = context;
 
   alarm (30);
 
@@ -146,11 +165,14 @@ test_basics (Fixture *f,
   g_subprocess_launcher_take_fd (launcher, sync_pipe[WRITE_END], 3);
   sync_pipe[WRITE_END] = -1;
 
+  if (params->use_fd_arg)
+    g_subprocess_launcher_take_fd (launcher, f->listen_fd, 4);
+
   f->proxy = g_subprocess_launcher_spawn (launcher, &error,
                                           f->proxy_path,
                                           "--fd=3",
                                           f->dbus_address,
-                                          f->proxy_socket,
+                                          params->use_fd_arg ? "fd:4" : f->proxy_socket,
                                           NULL);
   g_assert_no_error (error);
   g_assert_nonnull (f->proxy);
@@ -187,9 +209,9 @@ test_basics (Fixture *f,
       if (g_strcmp0 (strv[i], proxied_name) == 0)
         found = TRUE;
     }
-
   g_assert_true (found);
 }
+
 
 static void
 teardown (Fixture *f,
@@ -259,7 +281,11 @@ main (int argc,
 {
   g_test_init (&argc, &argv, NULL);
 
-  g_test_add ("/basics", Fixture, NULL, setup, test_basics, teardown);
+  static const TestParams test_without_fd = { .use_fd_arg = FALSE };
+  g_test_add ("/basics", Fixture, &test_without_fd, setup, test_basics, teardown);
+
+  static const TestParams test_with_fd = { .use_fd_arg = TRUE };
+  g_test_add ("/fd", Fixture, &test_with_fd, setup, test_basics, teardown);
 
   return g_test_run ();
 }

--- a/xdg-dbus-proxy.xml
+++ b/xdg-dbus-proxy.xml
@@ -31,7 +31,7 @@
 <cmdsynopsis>
 <command>xdg-dbus-proxy</command>
 <arg choice="opt" rep="repeat"><replaceable>OPTION</replaceable></arg>
-<arg choice="opt" rep="repeat"><replaceable>ADDRESS</replaceable> <replaceable>PATH</replaceable>
+<arg choice="opt" rep="repeat"><replaceable>ADDRESS</replaceable> <group choice="req"><replaceable>PATH</replaceable><arg choice="plain">fd:<replaceable>FD</replaceable></arg></group>
     <arg choice="opt" rep="repeat"><replaceable>OPTION</replaceable></arg>
 </arg>
 </cmdsynopsis>
@@ -45,7 +45,8 @@
 </para>
 <refsect2><title>Basic Operation</title>
 <para>
-  The proxy listens to the unix domain socket at <replaceable>PATH</replaceable>,
+  The proxy listens to the unix domain socket at <replaceable>PATH</replaceable>
+  (or on the pre-existing socket passed via <literal>fd:<replaceable>FD</replaceable></literal>),
   and for each client that connects to the socket, it opens up a new connection to
   the specified D-Bus <replaceable>ADDRESS</replaceable> (typically the session bus)
   and forwards data between the two. During the authentication phase all data is
@@ -213,6 +214,12 @@
 <refsect1><title>Examples</title>
 <para>
   <command>$ xdg-dbus-proxy --fd=26 unix:path=/run/usr/1000/bus /run/usr/1000/.dbus-proxy/session-bus-proxy --filter --own=org.gnome.ghex.* --talk=ca.desrt.dconf --call=org.freedesktop.portal.*=* --broadcast=org.freedesktop.portal.*=@/org/freedesktop/portal/*</command>
+</para>
+<para>
+  Using a pre-existing socket file descriptor (e.g. from systemd socket activation):
+</para>
+<para>
+  <command>$ xdg-dbus-proxy unix:path=/run/dbus/system_bus_socket fd:3 --filter --talk=org.freedesktop.NetworkManager</command>
 </para>
 </refsect1>
 


### PR DESCRIPTION
~~I'd like to submit two changes to xdg-dbus-proxy that make it easier to use with Systemd.~~

I'd like to submit a change that allows a file descriptor of an existing socket to be passed instead of a path for a new proxy socket.

~~The first change allows libsystemd to optionally be linked against to call `sd_notify(0, "READY=1")` before entering the main loop. This allows a Systemd service with `Type=notify` to be marked as active once xdg-dbus-proxy is fully initialized and ready.~~ This has been removed from this change, I'll look into this more and address this though a different PR.

The ~~second~~ change allows a file descriptor with `fd:` prepended to be passed instead of the current PATH positional argument. This allows sockets to be created before xdg-dbus-proxy is called. This is my proposed solution for #74.

As a cool demonstration of what this change can do, you can create a template socket and service file like so:

## xdg-dbus-proxyd@.socket
```
[Unit]
Description=D-Bus Proxy Socket (%I)

[Socket]
ListenStream=/run/xdg-dbus-proxyd-%i.sock
SocketMode=0660
SocketGroup=dbus-proxy

[Install]
WantedBy=sockets.target
```

## xdg-dbus-proxyd@.service
```
[Unit]
Description=D-Bus Proxy (%I)
Requires=xdg-dbus-proxyd@%i.socket

[Service]
Type=notify
EnvironmentFile=-/etc/xdg-dbus-proxyd/%i.conf
ExecStart=/usr/bin/xdg-dbus-proxy unix:path=/run/dbus/system_bus_socket fd:3
```

Now another service can invoke xdg-dbus-proxy by just adding the following.
```
Wants=xdg-dbus-proxyd@foo.socket
```

This example is really useful for compatibility with Podman quadlet files, so hopefully there's a way this support can be merged in :smile: 

Closes #44 