### PR TITLE
Allow clients to send signals with explicit destination

### DIFF
--- a/flatpak-proxy.c
+++ b/flatpak-proxy.c
@@ -1994,6 +1994,8 @@ get_dbus_method_handler (FlatpakProxyClient *client, Header *header)
   policy = flatpak_proxy_client_get_max_policy_and_matched (client, header->destination, &filters);
   if (policy < FLATPAK_POLICY_SEE)
     return HANDLE_HIDE;
+  if (header->type == G_DBUS_MESSAGE_TYPE_SIGNAL)
+    return HANDLE_PASS;
   if (policy < FLATPAK_POLICY_TALK)
     return HANDLE_DENY;
 


### PR DESCRIPTION
Currently clients are permitted to emit broadcast signals but are not allowed to emit signals with explicit destinations.

This is an issue because of the following sequence:
1. An client calls a method on a sandboxed client => The sandboxed client starts some asynchronous operation and returns success
2. The sandboxed client wants to inform the client that something happend to the operation (e.g. it finished). The client does this by emitting a signal destined to the calling client. => The signal might be blocked if we don't have permission to send to the destination

This behavior does not benefit security since a malicious client could just emit broadcast signals but breaks valid usecases thus this commit allows signals to be send to client that can be see.

Closes: https://github.com/flatpak/xdg-dbus-proxy/issues/25